### PR TITLE
Remove hardcoded api series path in datadog url

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -353,7 +353,7 @@ packages:
       properties:
         datadog:
           api_key: (( .properties.api_key.value ))
-          api_url: (( .properties.api_url.value ))/api/v1/series
+          api_url: (( .properties.api_url.value ))
           additional_api_key_1: (( .properties.additional_api_key_1.value ))
           additional_api_url_1: (( .properties.additional_api_url_1.value ))
           additional_api_key_2: (( .properties.additional_api_key_2.value ))


### PR DESCRIPTION
Need to be merged with a fix in the nozzle source code: https://github.com/DataDog/datadog-firehose-nozzle/pull/62